### PR TITLE
jwks: extract fetch method, add encode function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 bin/
 coverage.txt
 dist/

--- a/jwks.go
+++ b/jwks.go
@@ -1,0 +1,75 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+
+	"github.com/go-jose/go-jose/v3"
+)
+
+// EncodeJSONWebKeySetToPEM encodes the key set to PEM format using PKIX, ASN.1 DER form.
+func EncodeJSONWebKeySetToPEM(set *jose.JSONWebKeySet) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, key := range set.Keys {
+		der, err := x509.MarshalPKIXPublicKey(key.Key)
+		if err != nil {
+			return nil, err
+		}
+
+		err = pem.Encode(&buf, &pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: der,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// FetchJSONWebKeySet retrieves a JSONWebKeySet from an HTTP endpoint.
+func FetchJSONWebKeySet(ctx context.Context, client *http.Client, endpoint string) (*jose.JSONWebKeySet, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	bs, err := io.ReadAll(io.LimitReader(res.Body, defaultMaxBodySize))
+	if err != nil {
+		return nil, err
+	}
+
+	return parseJWKS(bs, true)
+}
+
+func parseJWKS(bs []byte, pub bool) (*jose.JSONWebKeySet, error) {
+	var jwks jose.JSONWebKeySet
+	if err := json.Unmarshal(bs, &jwks); err != nil {
+		return nil, err
+	}
+	if len(jwks.Keys) < 1 {
+		return nil, ErrJWKSNotFound
+	}
+
+	for _, j := range jwks.Keys {
+		if !j.Valid() {
+			return nil, ErrJWKSInvalid
+		}
+		if j.IsPublic() != pub {
+			return nil, ErrJWKSTypeMismatch
+		}
+	}
+
+	return &jwks, nil
+}

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -1,0 +1,38 @@
+package sdk
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"math/rand"
+	"testing"
+
+	"github.com/go-jose/go-jose/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchJSONWebKeySet(t *testing.T) {
+	random := rand.New(rand.NewSource(1))
+	k1, err := ecdsa.GenerateKey(elliptic.P256(), random)
+	require.NoError(t, err)
+	k2, err := ecdsa.GenerateKey(elliptic.P256(), random)
+	require.NoError(t, err)
+	k3, err := rsa.GenerateKey(random, 2048)
+	require.NoError(t, err)
+
+	jwks := &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{Key: k1.Public(), Use: "sig", Algorithm: string(jose.ES256)},
+			{Key: k2.Public(), Use: "sig", Algorithm: string(jose.ES256)},
+			{Key: k3.Public(), Use: "sig", Algorithm: string(jose.RS256)},
+		},
+	}
+	bs, err := EncodeJSONWebKeySetToPEM(jwks)
+	assert.NoError(t, err)
+	assert.Equal(t,
+		"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFdloxa3BKandzVW9jWjZlTnhmajZ6cld4bGU3RApYNUcwUDVNYzR2UklLTkdTWFlsOFpKci93dE9VQlhYUWx1Mk5HYkNRaXh4cUlFTEdKMWlRVjFHVGxRPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCi0tLS0tQkVHSU4gUFVCTElDIEtFWS0tLS0tCk1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRXM3L0daNHRJaUgvZFFXVGNxYzYvTjFiZzVMRDIKRlVjN1lTZmJBb0pLYmUyZy9iY0xUNnE3SGRZMjVZS3FTY0FxM2tyR3hoeHNMTENxb2VBTk1CWEJPQT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQotLS0tLUJFR0lOIFBVQkxJQyBLRVktLS0tLQpNSUlCSWpBTkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXRFSGkwMEl2QVRNNXNpTExFT3paCm95NkJTQXlEekxLU3ZrVGxPMjZ0bFdQL0oySkNGSjlSOU1rVkFxK3VPR2dsTGd2dmpNd1BjUzZ6TUlMYUIzNkMKRmV0OUJMTnRqNkFGZ2YybkM2d1ovS0hRSFpWbldFcmU4WmZ4N3dhSFV0QnRsa2E0NVRqcVV6YTE3VnZueDZaNwpyZDBkcnBsN285NHZJR05STkNuWC9SSUQrOUY5Z1hBM1RZeEtrU2dRWnU3eEdrdDRNMHpiMU9EdWtYeWprYVBlCjB3by9tRG1haWMzeFFYV0FsaWFnQnBGcWhiNk5oUUdPYkg5VndLVzVtOHh3Rm43dTU3SkNMMzZUMlVpcE1ob3oKa1hFRnFXVWE0b2lzc1FIYndEeUFOck8rdWdSZHV4cVhGeDJGUXUvRG1QbUlwNHVBU0ZTRFU0ajM5VjNVbnBJbgpjd0lEQVFBQgotLS0tLUVORCBQVUJMSUMgS0VZLS0tLS0K",
+		base64.StdEncoding.EncodeToString(bs),
+	)
+}


### PR DESCRIPTION
Extract the fetch method so that it can be used independently of the Verifier. Also add a new `EncodeJSONWebKeySetToPEM` function that encodes keys in the signing key format used by Pomerium.