### PR TITLE
Always validate JWT timestamps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/pomerium/sdk-go
 go 1.20
 
 require (
+	github.com/go-jose/go-jose/v3 v3.0.0
 	github.com/golangci/golangci-lint v1.52.2
 	github.com/stretchr/testify v1.8.3
-	gopkg.in/square/go-jose.v2 v2.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/go-critic/go-critic v0.7.0/go.mod h1:moYzd7GdVXE2C2hYTwd7h0CPcqlUecls
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
+github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
@@ -492,6 +494,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -554,6 +557,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
@@ -937,8 +941,6 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8X
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
-gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/jwks.go
+++ b/jwks.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"net/http"
 
-	jose "gopkg.in/square/go-jose.v2"
+	"github.com/go-jose/go-jose/v3"
 )
 
 // EncodeJSONWebKeySetToPEM encodes the key set to PEM format using PKIX, ASN.1 DER form.

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/stretchr/testify/assert"
-	jose "gopkg.in/square/go-jose.v2"
 )
 
 func TestFetchJSONWebKeySet(t *testing.T) {

--- a/sdk.go
+++ b/sdk.go
@@ -60,7 +60,8 @@ type Options struct {
 	// Logger is an optional custom logger which you provide.
 	Logger *log.Logger
 	// Expected defines values used for protected claims validation.
-	// If field has zero value then validation is skipped.
+	// If field has zero value then validation is skipped, with the exception
+	// of Time, where the zero value means "now."
 	Expected *jwt.Expected
 }
 

--- a/sdk.go
+++ b/sdk.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"strings"
 
-	jose "gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 )
 
 // errors

--- a/sdk.go
+++ b/sdk.go
@@ -134,11 +134,13 @@ func (v *Verifier) GetIdentity(ctx context.Context, rawJWT string) (*Identity, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal Pomerium JWT assertion: %w", err)
 	}
+	var expected jwt.Expected
 	if v.expected != nil {
-		err = id.Validate(*v.expected)
-		if err != nil {
-			return nil, fmt.Errorf("unexpected Pomerium JWT assertion claim: %w", err)
-		}
+		expected = *v.expected
+	}
+	err = id.Validate(expected)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected Pomerium JWT assertion claim: %w", err)
 	}
 	return &id, nil
 }

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -15,10 +15,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	jose "gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func TestVerifier_GetIdentity(t *testing.T) {
@@ -74,11 +74,11 @@ func TestVerifier_GetIdentity(t *testing.T) {
 		{"nil datastore should fail", "", nil, nil, nil, nil, defaultAttestationHeader, nil, nil, "", true, ""},
 		{"bad datastore url", "http://user:abc{DEf1=ghi@example.com", new(10), nil, nil, nil, defaultAttestationHeader, nil, nil, "", true, ""},
 		{"can't parse empty JWT", "", new(10), nil, nil, nil, defaultAttestationHeader, nil, nil, "", false, `{"error":"attestation token not found"}`},
-		{"can't parse malformed JWT", "", new(10), nil, nil, nil, defaultAttestationHeader, nil, nil, "malformed", false, `{"error":"failed to parse Pomerium JWT assertion: square/go-jose: compact JWS format must have three parts"}`},
-		{"bad signing key", ts.URL, new(10), nil, nil, nil, defaultAttestationHeader, badSigner, &Identity{Email: "user@pomerium.com"}, "", false, `{"error":"invalid Pomerium JWT assertion signature: square/go-jose: error in cryptographic primitive"}`},
+		{"can't parse malformed JWT", "", new(10), nil, nil, nil, defaultAttestationHeader, nil, nil, "malformed", false, `{"error":"failed to parse Pomerium JWT assertion: go-jose/go-jose: compact JWS format must have three parts"}`},
+		{"bad signing key", ts.URL, new(10), nil, nil, nil, defaultAttestationHeader, badSigner, &Identity{Email: "user@pomerium.com"}, "", false, `{"error":"invalid Pomerium JWT assertion signature: go-jose/go-jose: error in cryptographic primitive"}`},
 		{"good", ts.URL, new(10), nil, nil, nil, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com"}, "", false, "user@pomerium.com"},
 		{"good inferred verify endpoint", "", new(10), nil, nil, nil, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{Issuer: ts.URL}}, "", false, "user@pomerium.com"},
-		{"does not pass iss validation", ts.URL, new(10), nil, nil, &jwt.Expected{Issuer: "pomerium"}, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com"}, "", false, "{\"error\":\"unexpected Pomerium JWT assertion claim: square/go-jose/jwt: validation failed, invalid issuer claim (iss)\"}"},
+		{"does not pass iss validation", ts.URL, new(10), nil, nil, &jwt.Expected{Issuer: "pomerium"}, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com"}, "", false, "{\"error\":\"unexpected Pomerium JWT assertion claim: go-jose/go-jose/jwt: validation failed, invalid issuer claim (iss)\"}"},
 		{"does pass iss validation", ts.URL, new(10), nil, nil, &jwt.Expected{Issuer: ts.URL}, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{Issuer: ts.URL}}, "", false, "user@pomerium.com"},
 		{"good enforces sub validation", ts.URL, new(10), nil, nil, &jwt.Expected{Subject: "1234"}, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{Subject: "1234"}}, "", false, "user@pomerium.com"},
 	}

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -57,6 +58,11 @@ func TestVerifier_GetIdentity(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	start := time.Now()
+	iat := jwt.NewNumericDate(start)
+	fiveMinutesAgo := jwt.NewNumericDate(start.Add(-5 * time.Minute))
+	fiveMinutesFromNow := jwt.NewNumericDate(start.Add(5 * time.Minute))
+
 	tests := []struct {
 		name        string
 		jwkEndpoint string
@@ -76,11 +82,13 @@ func TestVerifier_GetIdentity(t *testing.T) {
 		{"can't parse empty JWT", "", new(10), nil, nil, nil, defaultAttestationHeader, nil, nil, "", false, `{"error":"attestation token not found"}`},
 		{"can't parse malformed JWT", "", new(10), nil, nil, nil, defaultAttestationHeader, nil, nil, "malformed", false, `{"error":"failed to parse Pomerium JWT assertion: go-jose/go-jose: compact JWS format must have three parts"}`},
 		{"bad signing key", ts.URL, new(10), nil, nil, nil, defaultAttestationHeader, badSigner, &Identity{Email: "user@pomerium.com"}, "", false, `{"error":"invalid Pomerium JWT assertion signature: go-jose/go-jose: error in cryptographic primitive"}`},
-		{"good", ts.URL, new(10), nil, nil, nil, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com"}, "", false, "user@pomerium.com"},
+		{"good", ts.URL, new(10), nil, nil, nil, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{IssuedAt: iat, Expiry: fiveMinutesFromNow}}, "", false, "user@pomerium.com"},
 		{"good inferred verify endpoint", "", new(10), nil, nil, nil, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{Issuer: ts.URL}}, "", false, "user@pomerium.com"},
 		{"does not pass iss validation", ts.URL, new(10), nil, nil, &jwt.Expected{Issuer: "pomerium"}, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com"}, "", false, "{\"error\":\"unexpected Pomerium JWT assertion claim: go-jose/go-jose/jwt: validation failed, invalid issuer claim (iss)\"}"},
 		{"does pass iss validation", ts.URL, new(10), nil, nil, &jwt.Expected{Issuer: ts.URL}, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{Issuer: ts.URL}}, "", false, "user@pomerium.com"},
 		{"good enforces sub validation", ts.URL, new(10), nil, nil, &jwt.Expected{Subject: "1234"}, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{Subject: "1234"}}, "", false, "user@pomerium.com"},
+		{"expired", ts.URL, new(10), nil, nil, nil, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{IssuedAt: fiveMinutesAgo, Expiry: fiveMinutesAgo}}, "", false, `{"error":"unexpected Pomerium JWT assertion claim: go-jose/go-jose/jwt: validation failed, token is expired (exp)"}`},
+		{"issued in the future", ts.URL, new(10), nil, nil, nil, defaultAttestationHeader, goodSigner, &Identity{Email: "user@pomerium.com", Claims: jwt.Claims{IssuedAt: fiveMinutesFromNow, Expiry: fiveMinutesFromNow}}, "", false, `{"error":"unexpected Pomerium JWT assertion claim: go-jose/go-jose/jwt: validation field, token issued in the future (iat)"}`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Update to go-jose v3. This version changes the default behavior of the jwt.Claims Validate() method to validate the JWT timestamps against the current time.

Update the test cases to account for the new package name.

Change Verifier.GetIdentity() to always call the jwt.Claims Validate() method, even when the Expected field is nil, so that we still validate the "iat" and "exp" timestamps.

Add test cases for both the "expired" and "not yet issued" scenarios.