### PR TITLE
specify JSONWebKeyStore more precisely

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -29,8 +29,8 @@ var (
 
 // JSONWebKeyStore is the interface to for storing JSON Web Keys.
 type JSONWebKeyStore interface {
-	Get(key interface{}) (value interface{}, ok bool)
-	Add(key, value interface{})
+	Get(keyID string) (value *jose.JSONWebKey, ok bool)
+	Add(keyID string, value *jose.JSONWebKey)
 }
 
 const (
@@ -157,7 +157,7 @@ func (v *Verifier) getJSONWebKeyFromToken(ctx context.Context, rawJWT string) (*
 	}
 	h := tok.Headers[0]
 	if val, ok := v.datastore.Get(h.KeyID); ok {
-		return val.(*jose.JSONWebKey), nil
+		return val, nil
 	}
 
 	verifyEndpoint, err := v.getVerifyEndpoint(tok)

--- a/sdk_test.go
+++ b/sdk_test.go
@@ -172,30 +172,29 @@ var _ JSONWebKeyStore = &mockCache{}
 
 type mockCache struct {
 	capacity int
-	data     map[string]interface{}
-	keys     []string
+	data     map[string]*jose.JSONWebKey
+	keyIDs   []string
 }
 
 func new(capacity int) *mockCache {
 	return &mockCache{
 		capacity: capacity,
-		data:     make(map[string]interface{}),
-		keys:     make([]string, capacity),
+		data:     make(map[string]*jose.JSONWebKey),
+		keyIDs:   make([]string, capacity),
 	}
 }
 
-func (c *mockCache) Get(key interface{}) (interface{}, bool) {
-	val, ok := c.data[fmt.Sprintf("%s", key)]
+func (c *mockCache) Get(keyID string) (*jose.JSONWebKey, bool) {
+	val, ok := c.data[keyID]
 	return val, ok
 }
 
-func (c *mockCache) Add(key, value interface{}) {
+func (c *mockCache) Add(keyID string, value *jose.JSONWebKey) {
 	slot := len(c.data)
 	if len(c.data) == c.capacity {
 		slot = rand.Intn(c.capacity)
-		delete(c.data, c.keys[slot])
+		delete(c.data, c.keyIDs[slot])
 	}
-	keyString := fmt.Sprintf("%s", key)
-	c.keys[slot] = keyString
-	c.data[keyString] = value
+	c.keyIDs[slot] = keyID
+	c.data[keyID] = value
 }


### PR DESCRIPTION
Change the JSONWebKeyStore type definition to specify the actual key and value types that are used with it. This should allow us to take full advantage of the generics support in [github.com/hashicorp/golang-lru/v2](https://pkg.go.dev/github.com/hashicorp/golang-lru/v2) when adding a default implementation for this interface.