### PR TITLE
add Name field to the Identity struct

### DIFF
--- a/sdk.go
+++ b/sdk.go
@@ -102,6 +102,7 @@ type Identity struct {
 	Groups     []string `json:"groups,omitempty"`
 	User       string   `json:"user,omitempty"`
 	Email      string   `json:"email,omitempty"`
+	Name       string   `json:"name,omitempty"`
 	RawJWT     string   `json:"raw_jwt,omitempty"`
 	PublicKey  string   `json:"public_key,omitempty"`
 }


### PR DESCRIPTION
As of v0.18, the Pomerium JWT will include a 'name' claim by default (if supported by the identity provider). Add a corresponding field to the sdk.Identity struct.

Fixes #93.