### PR TITLE
sdk-go/ci: upgrade golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,9 +17,9 @@ jobs:
 
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.20.x
-          cache: true
+          go-version: 1.21.x
+          cache: false
 
       - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
-          version: v1.51
+          version: v1.55

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,8 +19,7 @@ jobs:
 
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.20.x
-          cache: true
+          go-version: 1.21.x
 
       - name: test
         run: make cover

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - errcheck
     - gofmt
@@ -70,29 +69,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    # - asciicheck
-    # - dupl
-    # - exhaustive
-    # - funlen
-    # - gochecknoglobals
-    # - gochecknoinits
-    # - gocognit
-    # - goconst
-    # - gocritic
-    # - gocyclo
-    # - godot
-    # - godox
-    # - goerr113
-    # - gomnd
-    # - interfacer
-    # - maligned
-    # - nestif
-    # - noctx
-    # - prealloc
-    # - scopelint
-    # - testpackage
-    # - whitespace
-    # - wsl
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.20.3
+golang 1.21.3

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,13 @@ clean: ## Cleanup any build binaries or packages.
 	$(RM) -r $(BINDIR)
 	$(RM) coverage.txt
 
-.PHONY: build-deps
-build-deps: ## Install build dependencies
-	@echo "==> $@"
-
 .PHONY: build
 build: ## Builds dynamic executables and/or packages.
 	@echo "==> $@"
 	@go build -o $(BINDIR)/$(NAME)
 
 .PHONY: lint
-lint: build-deps ## Verifies `golint` passes.
+lint:
 	@echo "==> $@"
 	@VERSION=$$(go run github.com/mikefarah/yq/v4@v4.34.1 '.jobs.lint.steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version' .github/workflows/lint.yaml) && \
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$$VERSION run ./...


### PR DESCRIPTION
For https://github.com/pomerium/internal/issues/1633

Upgrade `golangci-lint` 