### PR TITLE
readme: update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://github.com/pomerium/sdk-go/workflows/build/badge.svg)](https://github.com/pomerium/sdk-go/actions?workflow=build)
+[![Build Status](https://github.com/pomerium/sdk-go/actions/workflows/test.yaml/badge.svg)](https://github.com/pomerium/sdk-go/actions/workflows/test.yaml)
 [![codecov](https://img.shields.io/codecov/c/github/pomerium/sdk-go.svg?style=flat)](https://codecov.io/gh/pomerium/sdk-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pomerium/sdk-go)](https://goreportcard.com/report/github.com/pomerium/sdk-go)
 [![GoDoc](https://godoc.org/github.com/pomerium/sdk-go?status.svg)](https://godoc.org/github.com/pomerium/sdk-go)
 [![LICENSE](https://img.shields.io/github/license/pomerium/sdk-go.svg)](https://github.com/pomerium/sdk-go/blob/master/LICENSE)
-[![pomerium chat](https://img.shields.io/badge/chat-on%20slack-blue.svg?style=flat&logo=slack)](http://slack.pomerium.io)
+[![discuss](https://img.shields.io/discourse/posts?server=https%3A%2F%2Fdiscuss.pomerium.com%2F&label=discuss)](https://discuss.pomerium.com/)
 
 # Pomerium's Go (Golang) SDK
 


### PR DESCRIPTION
Replace the Slack badge with a link to https://discuss.pomerium.com and update the broken build status badge.

Related issue:

- https://github.com/pomerium/internal/issues/1858