### PR TITLE
client: strip monotonic clock reading from expiry

### DIFF
--- a/zero_client.go
+++ b/zero_client.go
@@ -92,8 +92,14 @@ func loadZeroToken(ctx context.Context, cfg *clientConfig) (zeroToken, error) {
 		return zeroToken{}, fmt.Errorf("error parsing token expiry: %w", err)
 	}
 
+	// Strip the monotonic clock reading from the expiry, so that any time
+	// comparison will use only the wall clock time. (On some systems, the
+	// monotonic clock does not advance during system sleep, which could
+	// lead to incorrect expiration time checks.)
+	expiry := now.Add(time.Second * time.Duration(expires)).Round(0)
+
 	return zeroToken{
-		expiry:  now.Add(time.Second * time.Duration(expires)).Round(0),
+		expiry:  expiry,
 		idToken: resData.IDToken,
 	}, nil
 }

--- a/zero_client.go
+++ b/zero_client.go
@@ -93,7 +93,7 @@ func loadZeroToken(ctx context.Context, cfg *clientConfig) (zeroToken, error) {
 	}
 
 	return zeroToken{
-		expiry:  now.Add(time.Second * time.Duration(expires)),
+		expiry:  now.Add(time.Second * time.Duration(expires)).Round(0),
 		idToken: resData.IDToken,
 	}, nil
 }


### PR DESCRIPTION
The time.After() check used to determine if a Pomerium Zero ID token has expired will currently compare the monotonic clock readings rather than the wall time. This can be problematic when running a client for an extended period of time on a laptop, as the monotonic clock reading may not advance while the laptop is asleep.

Instead, let's strip the monotonic clock reading from the expiry, so that the comparison uses only the wall time. From the documentation at https://pkg.go.dev/time "The canonical way to strip a monotonic clock reading is to use t = t.Round(0)."

Unfortunately I don't see an easy way to exercise this behavior in a unit test.