### PR TITLE
ci: add a job that notifies dependencies when commits are made

### DIFF
--- a/.github/workflows/notify-dependencies.yaml
+++ b/.github/workflows/notify-dependencies.yaml
@@ -1,0 +1,32 @@
+name: Notify Dependencies
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+      - 0-[0-9]+-*
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - ingress-controller
+          - pomerium-console
+          - pomerium-zero
+          - terraform-provider-pomerium
+          - verify
+    steps:
+      - name: Notify
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+        with:
+          ref: main
+          repo: pomerium/${{ matrix.repo }}
+          sync-status: true
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+          wait-for-completion: true
+          workflow: update-dependencies.yaml


### PR DESCRIPTION
## Summary
When a commit is made to main or a release branch we should notify other repositories that an update was made.

## Related issues
For [ENG-4257](https://linear.app/pomerium/issue/ENG-4257/various-trigger-update-dependency-jobs-on-push)
