### PR TITLE
ci: add 'go mod tidy' in update-dependencies script

### DIFF
--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -17,6 +17,7 @@ update-pomerium() {
 
 	go get -u github.com/pomerium/pomerium/pkg/grpc/config@main
 	go get -u github.com/pomerium/pomerium/pkg/grpc/databroker@main
+	go mod tidy
 
 	popd
 }


### PR DESCRIPTION
Add a `go mod tidy` step to the update-dependencies script.